### PR TITLE
Set properties to 'null' updates

### DIFF
--- a/src/OmniAural.js
+++ b/src/OmniAural.js
@@ -654,18 +654,12 @@ class OmniAural {
                         }
 
                         const obj = getOmniAuralPropertyAtPath(path)
+                        obj.set(path, params);
 
-                        if (params === null) {
-                            this._deleteProperty(path)
-                            OmniAural.addProperty(path, null)
-                        } else {
-                            obj.set(path, params);
-
-                            if (obj.observers.has(path)) {
-                                obj.observers.get(path).forEach((callback) => {
-                                    callback();
-                                });
-                            }
+                        if (obj.observers.has(path)) {
+                            obj.observers.get(path).forEach((callback) => {
+                                callback();
+                            });
                         }
                     },
                     value: () => {
@@ -785,10 +779,13 @@ class OmniAural {
                     set: function (path, params) {
                         if (params !== null) {
                             const keys = Object.keys(params)
-                            if(keys.length) {
+                            const obj = getOmniAuralPropertyAtPath(path)
+                            if(obj.value === null) {
+                                obj.value = {}
+                            } 
+                            
+                            if (keys.length) {
                                 keys.forEach(function (key) {
-                                    const obj = getOmniAuralPropertyAtPath(path)
-                                    
                                     if (!obj.value.hasOwnProperty(key)) {
                                         OmniAural.addProperty(path + '.' + key, params[key])
                                     } else {
@@ -796,27 +793,21 @@ class OmniAural {
                                     }
                                 });
                             } else {
-                                keys.forEach(function (key) {
-                                    const obj = getOmniAuralPropertyAtPath(path)
-
-                                    obj.delete(path + '.' + key)
-                                });
-
                                 this.value = params
                             }
                         } else {
-                            Object.keys(this.value).forEach(function (key) {
-                                const childPath = path + '.' + key
-                                const obj = getOmniAuralPropertyAtPath(childPath)
-                                obj.delete(childPath)
-                            });
+                            this.value = null
                         }
 
                         if (this.context[path]) {
                             for (const contextKey in this.context[path]) {
-                                this.context[path][contextKey](
-                                    Object.assign(sanitize(this), params)
-                                );
+                                let newValue = null
+
+                                if (params !== null) {
+                                    newValue = Object.assign(sanitize(this), params)
+                                }
+
+                                this.context[path][contextKey](newValue);
                             }
                         }
 

--- a/src/OmniAural.js
+++ b/src/OmniAural.js
@@ -962,10 +962,6 @@ class OmniAural {
                     }
                 });
 
-                if (propertyObject.context[path]) {
-                    delete propertyObject.context[path][listener.component.omniId]
-                }
-
                 Object.keys(listener.component.omniAuralMap).forEach((key) => {
                     if (listener.component.omniAuralMap[key].startsWith(path)) {
                         delete listener.component.omniAuralMap[key]
@@ -973,6 +969,13 @@ class OmniAural {
                 })
             }
         })
+
+        if (propertyObject.context[path]) {
+            for (const contextKey in propertyObject.context[path]) {
+                propertyObject.context[path][contextKey](null);
+            }
+            delete propertyObject.context[path]
+        }
 
         if (isObject(propertyObject.value)) {
             Object.keys(propertyObject.value).forEach((key) => {
@@ -1040,7 +1043,9 @@ export const useOmniAural = (path) => {
         omniObject.context[path][omniAuralId] = setProperty
 
         return () => {
-            delete omniObject.context[path][omniAuralId];
+            if (omniObject.context[path]){
+                delete omniObject.context[path][omniAuralId];
+            }
         };
     }, [path, omniObject.context]);
 

--- a/tests/MyComponent.js
+++ b/tests/MyComponent.js
@@ -8,7 +8,7 @@ export default class MyComponent extends React.Component {
             description: "Small Description"
         }
 
-        OmniAural.register(this, ["account.name as name", "account.name as person.name", "account.address", "account.address.street as street", "account as info.account", "purchase"])
+        OmniAural.register(this, ["account.name as name", "account.name as person.name", "account.address", "account.address.street as street", "account as info.account", "purchase", "nulledPurchase"])
         OmniAural.register(this, ["account.phone_number as number"], () => {
             console.log("Global State Changed")
         })
@@ -20,6 +20,10 @@ export default class MyComponent extends React.Component {
 
     _addZipCode = () => {
         OmniAural.addProperty("account.address", { zip: 12345 })
+    }
+
+    _setPurchaseToNull = () => {
+        OmniAural.state.nulledPurchase.set(null)
     }
 
     _updateNameLocally = () => {
@@ -68,7 +72,8 @@ export default class MyComponent extends React.Component {
             <div onClick={this._updateNameLocallyAlt}>{this.state.person.name}</div>
             <div onClick={this._updateDescription}>{this.state.description}</div>
             <div onClick={this._updateDescriptionAlt}>{this.state.description}</div>
-            <div onClick={this._deletePurchase}>Test</div>
+            <div onClick={this._deletePurchase}>Purchase Test</div>
+            <div onClick={this._setPurchaseToNull}>{`${this.state.nulledPurchase}`}</div>
             <div>{this.state.phoneNumber}</div>
         </div>
     }

--- a/tests/MyHooksFunctional.js
+++ b/tests/MyHooksFunctional.js
@@ -5,8 +5,10 @@ export default () => {
     const [name] = useOmniAural("account.name")
     const [address] = useOmniAural("account.address")
     const [currentEmployment] = useOmniAural("account.currentEmployment")
+    const [nulledOut] = useOmniAural("nulledOut")
 
     let employmentCity
+    let customValue
 
     useOmniAuralEffect(() => {
         console.log(OmniAural.state.account.id.value())
@@ -16,10 +18,15 @@ export default () => {
         employmentCity = currentEmployment.address.city
     }
 
+    if(nulledOut) {
+        customValue = nulledOut.key
+    }
+
     return <div>
         <div>{name}</div>
         <div>{`${address.street} in ${address.city}`}</div>
         <div>{`Works in ${employmentCity}`}</div>
+        <div>{`${customValue}`}</div>
     </div>
 }
 

--- a/tests/__snapshots__/components.test.js.snap
+++ b/tests/__snapshots__/components.test.js.snap
@@ -11,6 +11,9 @@ exports[`Component Testing OmniAural Hooks Hook is created with the correct valu
   <div>
     Works in Chicago
   </div>
+  <div>
+    value
+  </div>
 </div>
 `;
 
@@ -24,6 +27,26 @@ exports[`Component Testing OmniAural Hooks Hook is updated when nested object is
   </div>
   <div>
     Works in Chicago
+  </div>
+  <div>
+    value
+  </div>
+</div>
+`;
+
+exports[`Component Testing OmniAural Hooks Hook is updated when nested object is set to null 1`] = `
+<div>
+  <div>
+    Evan
+  </div>
+  <div>
+    undefined in Chicago
+  </div>
+  <div>
+    Works in undefined
+  </div>
+  <div>
+    value
   </div>
 </div>
 `;
@@ -39,6 +62,9 @@ exports[`Component Testing OmniAural Hooks Hook is updated when nested value is 
   <div>
     Works in Chicago
   </div>
+  <div>
+    value
+  </div>
 </div>
 `;
 
@@ -52,6 +78,9 @@ exports[`Component Testing OmniAural Hooks Hook is updated with the correct nest
   </div>
   <div>
     Works in Chicago
+  </div>
+  <div>
+    value
   </div>
 </div>
 `;
@@ -67,6 +96,9 @@ exports[`Component Testing OmniAural Hooks Hook is updated with the correct nest
   <div>
     Works in Chicago
   </div>
+  <div>
+    value
+  </div>
 </div>
 `;
 
@@ -80,6 +112,9 @@ exports[`Component Testing OmniAural Hooks Hook is updated with the correct valu
   </div>
   <div>
     Works in Chicago
+  </div>
+  <div>
+    value
   </div>
 </div>
 `;
@@ -131,7 +166,12 @@ exports[`Component Testing The Class Component should register and contain the a
   <div
     onClick={[Function]}
   >
-    Test
+    Purchase Test
+  </div>
+  <div
+    onClick={[Function]}
+  >
+    200
   </div>
   <div />
 </div>
@@ -184,7 +224,12 @@ exports[`Component Testing The Class Component should register and contain the a
   <div
     onClick={[Function]}
   >
-    Test
+    Purchase Test
+  </div>
+  <div
+    onClick={[Function]}
+  >
+    200
   </div>
   <div />
 </div>

--- a/tests/__snapshots__/components.test.js.snap
+++ b/tests/__snapshots__/components.test.js.snap
@@ -34,7 +34,24 @@ exports[`Component Testing OmniAural Hooks Hook is updated when nested object is
 </div>
 `;
 
-exports[`Component Testing OmniAural Hooks Hook is updated when nested object is set to null 1`] = `
+exports[`Component Testing OmniAural Hooks Hook is updated when nested value is deleted 1`] = `
+<div>
+  <div>
+    Evan
+  </div>
+  <div>
+    Randolph in Chicago
+  </div>
+  <div>
+    Works in Chicago
+  </div>
+  <div>
+    value
+  </div>
+</div>
+`;
+
+exports[`Component Testing OmniAural Hooks Hook is updated when null object is set to a value 1`] = `
 <div>
   <div>
     Evan
@@ -46,21 +63,21 @@ exports[`Component Testing OmniAural Hooks Hook is updated when nested object is
     Works in undefined
   </div>
   <div>
-    value
+    undefined
   </div>
 </div>
 `;
 
-exports[`Component Testing OmniAural Hooks Hook is updated when nested value is deleted 1`] = `
+exports[`Component Testing OmniAural Hooks Hook is updated when property is set to null 1`] = `
 <div>
   <div>
     Evan
   </div>
   <div>
-    Randolph in Chicago
+    undefined in Chicago
   </div>
   <div>
-    Works in Chicago
+    Works in undefined
   </div>
   <div>
     value

--- a/tests/components.test.js
+++ b/tests/components.test.js
@@ -521,7 +521,7 @@ describe("Component Testing", () => {
       ).toBeTruthy();
     });
 
-    test("Hook is updated when nested object is set to null", () => {
+    test("Hook is updated when property is set to null", () => {
       let component;
 
       act(() => {
@@ -545,6 +545,33 @@ describe("Component Testing", () => {
       tree = component.toJSON();
       expect(
         tree.children[3].children.includes("undefined")
+      ).toBeTruthy();
+    });
+
+    test("Hook is updated when null object is set to a value", () => {
+      let component;
+
+      act(() => {
+        component = renderer.create(<MyHooksFunctional />);
+      });
+
+      let tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+      expect(
+        tree.children[3].children.includes("undefined")
+      ).toBeTruthy();
+
+      act(() => {
+        OmniAural.state.nulledOut.set({key:"value"});
+      });
+
+      expect(
+        OmniAural.state.nulledOut.key.value()
+      ).toBe("value");
+
+      tree = component.toJSON();
+      expect(
+        tree.children[3].children.includes("value")
       ).toBeTruthy();
     });
 

--- a/tests/components.test.js
+++ b/tests/components.test.js
@@ -255,6 +255,19 @@ describe("Component Testing", () => {
       ).toThrow("Cannot read property 'value' of undefined");
     });
 
+    test("Set a previously registered property to null", () => {
+      let component = renderer.create(<MyComponent />);
+      let tree = component.toJSON();
+
+      tree.children[11].children.includes("200");
+      tree.children[11].props.onClick();
+      tree = component.toJSON();
+      expect(OmniAural.state.nulledPurchase.value()).toBeNull()
+      expect(OmniAural.UnsafeGlobalInstance.value["nulledPurchase"].value).toBeNull()
+
+      tree.children[11].children.includes("null");
+    });
+
     test("should throw an error if trying to register for an nonexistent property", () => {
       expect(() => shallow(<MyBadComponent />)).toThrow();
     });
@@ -352,6 +365,7 @@ describe("Component Testing", () => {
         expect(consoleOutput).toEqual([
           "Global State Changed",
           "Global State Changed",
+          "Global State Changed"
         ]);
 
         component.unmount();
@@ -504,6 +518,33 @@ describe("Component Testing", () => {
       tree = component.toJSON();
       expect(
         tree.children[2].children.includes("Works in undefined")
+      ).toBeTruthy();
+    });
+
+    test("Hook is updated when nested object is set to null", () => {
+      let component;
+
+      act(() => {
+        component = renderer.create(<MyHooksFunctional />);
+      });
+
+      let tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+      expect(
+        tree.children[3].children.includes("value")
+      ).toBeTruthy();
+
+      act(() => {
+        OmniAural.state.nulledOut.set(null);
+      });
+
+      expect(
+        OmniAural.state.nulledOut.value()
+      ).toBeNull();
+
+      tree = component.toJSON();
+      expect(
+        tree.children[3].children.includes("undefined")
       ).toBeTruthy();
     });
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -379,7 +379,7 @@ describe("Global State Updater", () => {
     OmniAural.state.objectToDelete.set(null);
 
     expect(() => OmniAural.state.objectToDelete.innerValue.value()).toThrow(
-      "Cannot read property 'value' of undefined"
+      "Cannot read property 'innerValue' of null"
     );
     expect(OmniAural.state.objectToDelete.value()).toBe(null);
   });

--- a/tests/mockInitialState.js
+++ b/tests/mockInitialState.js
@@ -23,5 +23,9 @@ export default {
             amount: 300
         }
     },
+    nulledPurchase:200,
+    nulledOut: {
+        key: "value"
+    },
     items: []
 }


### PR DESCRIPTION
1. OmniAural should consider null as intentional and should not delete any omniaural objects when something is set to null. 
2. hooks and observers should both listen to, and react to null value setting